### PR TITLE
Add casino commands to discord bot

### DIFF
--- a/carfigures/commands/coins.py
+++ b/carfigures/commands/coins.py
@@ -3,6 +3,7 @@
 import discord
 from discord.ext import commands
 from datetime import datetime
+import random
 
 from carfigures.utils.coins import CoinManager
 
@@ -50,6 +51,74 @@ class CoinsCommands(commands.Cog):
             )
         
         embed.set_footer(text="Use !balance to check your coin balance")
+        await ctx.send(embed=embed)
+    
+    @commands.command(name="casino", aliases=["gamble", "bet"])
+    @commands.cooldown(1, 10, commands.BucketType.user)
+    async def casino(self, ctx, amount: str = None):
+        """Gamble your coins. Usage: !casino <amount|all|half>"""
+        if amount is None:
+            await ctx.send(f"Usage: `{self.bot.command_prefix}casino <amount|all|half>`")
+            return
+        
+        user_id = ctx.author.id
+        balance = await CoinManager.get_balance(user_id)
+        
+        # Parse bet amount
+        bet_amount: int
+        arg = amount.lower()
+        if arg == "all":
+            bet_amount = balance
+        elif arg == "half":
+            bet_amount = max(1, balance // 2)
+        else:
+            try:
+                bet_amount = int(arg)
+            except ValueError:
+                await ctx.send("Enter a valid number, or use `all`/`half`.")
+                return
+        
+        # Validate bet
+        min_bet = 10
+        if bet_amount < min_bet:
+            await ctx.send(f"Minimum bet is {min_bet} coins.")
+            return
+        if bet_amount > balance:
+            await ctx.send("You don't have enough coins for that bet.")
+            return
+        
+        # Take the bet
+        success, _ = await CoinManager.spend_coins(user_id, bet_amount)
+        if not success:
+            await ctx.send("You don't have enough coins for that bet.")
+            return
+        
+        # Resolve outcome (47% win chance)
+        win = random.random() < 0.47
+        if win:
+            winnings = bet_amount * 2
+            await CoinManager.add_coins(user_id, winnings, "Casino win")
+            new_balance = await CoinManager.get_balance(user_id)
+            embed = discord.Embed(
+                title="🎰 Casino Result",
+                description=f"You won! +{winnings:,} coins",
+                color=0x00ff00
+            )
+            embed.add_field(name="Bet", value=f"{bet_amount:,}")
+            embed.add_field(name="Chance", value="47% win")
+            embed.add_field(name="New Balance", value=f"{new_balance:,}")
+        else:
+            new_balance = await CoinManager.get_balance(user_id)
+            embed = discord.Embed(
+                title="🎰 Casino Result",
+                description=f"You lost {bet_amount:,} coins",
+                color=0xff0000
+            )
+            embed.add_field(name="Bet", value=f"{bet_amount:,}")
+            embed.add_field(name="Chance", value="53% lose")
+            embed.add_field(name="New Balance", value=f"{new_balance:,}")
+        
+        embed.set_footer(text="Gamble responsibly. Cooldown: 10s")
         await ctx.send(embed=embed)
     
     @commands.command(name="balance", aliases=["coins", "bal"])

--- a/carfigures/commands/general.py
+++ b/carfigures/commands/general.py
@@ -50,7 +50,8 @@ class GeneralCommands(commands.Cog):
             coin_commands = (
                 f"`{self.bot.command_prefix}daily` - Claim daily coin reward\n"
                 f"`{self.bot.command_prefix}balance` - Check your coin balance\n"
-                f"`{self.bot.command_prefix}leaderboard` - View top coin holders"
+                f"`{self.bot.command_prefix}leaderboard` - View top coin holders\n"
+                f"`{self.bot.command_prefix}casino <amount|all|half>` - Gamble your coins"
             )
             embed.add_field(name="💰 Coin Commands", value=coin_commands, inline=False)
             


### PR DESCRIPTION
Add a new `!casino` command to allow users to gamble their in-bot currency.

---
<a href="https://cursor.com/background-agent?bcId=bc-62cc374d-2c55-49e4-87e7-58f3eb4ba06c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-62cc374d-2c55-49e4-87e7-58f3eb4ba06c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

